### PR TITLE
Add GetPageSpeed Extras for Debian/Ubuntu to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ For more details, see [nginx.org](http://nginx.org/en/docs/).
 * [nginx-binaries](https://github.com/jirutka/nginx-binaries) - Nginx and njs binaries for Linux (x86_64, aarch64, ppc64le), macOS and Windows; Linux binaries are static so works on every Linux.
 * [NPMplus](https://github.com/ZoeyVid/NPMplus) - Docker container for managing Nginx proxy hosts with a simple, powerful interface
 * [nginx-modules](https://github.com/blendbyte/nginx-modules) - APT repository providing pre-built NGINX dynamic modules for Debian and Ubuntu (amd64/arm64), installable via `apt` without compiling from source.
+* [GetPageSpeed Extras for Debian/Ubuntu](https://www.getpagespeed.com/ubuntu-and-debian-repository) - Free APT repository with 100+ pre-built NGINX dynamic modules for Debian (Bookworm/Trixie) and Ubuntu (Bionic/Focal/Jammy/Noble) on amd64 and arm64. No signup or auth required. Covers ModSecurity, brotli, geoip2, headers-more, JWT, TOTP, naxsi, NJS, and a long tail of modules not packaged elsewhere. Cross-distro counterpart for RHEL/SLES/Amazon Linux at extras.getpagespeed.com.
 
 ## Tutorials
 * [Nginx admin guide](https://www.nginx.com/resources/admin-guide/) - Nginx and nginx plus admin guide. 


### PR DESCRIPTION
Adds GetPageSpeed's Debian/Ubuntu APT repository to the Tools section, adjacent to the recently-merged blendbyte/nginx-modules entry (#58).

Same problem space (pre-built NGINX dynamic modules as APT packages, no source compilation), broader coverage:

- 100+ pre-built `nginx-module-*` packages vs ~10 in similar repos
- Free, no signup, no auth: anonymous `apt install` after a one-line keyring setup
- Distros: Debian Bookworm/Trixie, Ubuntu Bionic/Focal/Jammy/Noble (+ `-mainline` variants for nginx mainline)
- Architectures: amd64 and arm64 for every codename
- Covers ModSecurity, brotli, geoip2, headers-more, JWT, TOTP, naxsi, NJS, push-stream, RTMP/HLS, lua, and a long tail of modules not packaged elsewhere
- Cross-distro counterpart on extras.getpagespeed.com for RHEL, SLES, Amazon Linux, Fedora

GetPageSpeed-owned source modules (`GetPageSpeed/ngx_immutable`, `GetPageSpeed/ngx_security_headers`) are already listed in awesome-nginx; this entry covers the packaging/distribution layer that complements them.