### PR TITLE
Add nginx-scanner-trap to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ For more details, see [nginx.org](http://nginx.org/en/docs/).
 * [nginx-modules](https://github.com/blendbyte/nginx-modules) - APT repository providing pre-built NGINX dynamic modules for Debian and Ubuntu (amd64/arm64), installable via `apt` without compiling from source.
 * [GetPageSpeed Extras for Debian/Ubuntu](https://www.getpagespeed.com/ubuntu-and-debian-repository) - Free APT repository with 100+ pre-built NGINX dynamic modules for Debian (Bookworm/Trixie) and Ubuntu (Bionic/Focal/Jammy/Noble) on amd64 and arm64. No signup or auth required. Covers ModSecurity, brotli, geoip2, headers-more, JWT, TOTP, naxsi, NJS, and a long tail of modules not packaged elsewhere. Cross-distro counterpart for RHEL/SLES/Amazon Linux at extras.getpagespeed.com.
 * [seo-sidecar](https://github.com/Janady13/seo-sidecar) - FastAPI + nginx SSI sidecar that injects fresh Schema.org JSON-LD into nginx-served sites without redeploys or cron jobs. Production-ready, MIT licensed.
+* [nginx-scanner-trap](https://github.com/gistrec/nginx-scanner-trap) - One-script honeypot for existing nginx servers: bots probing paths like /.env or /.git get banned on all ports via fail2ban + nftables. Interactive install with whitelisting, dry-run preview, Debian/Ubuntu, MIT licensed.
 
 ## Tutorials
 * [Nginx admin guide](https://www.nginx.com/resources/admin-guide/) - Nginx and nginx plus admin guide. 


### PR DESCRIPTION
Adds [nginx-scanner-trap](https://github.com/gistrec/nginx-scanner-trap) to the Tools section.

A single bash script that turns an existing nginx server into a trap for vulnerability scanners: a honeypot `location` catches the first probe of paths like `/.env` or `/.git`, and fail2ban + nftables ban the source IP on all ports. Interactive install with admin-IP whitelisting, `--dry-run` preview, published checksums, synthetic end-to-end test ban. Debian/Ubuntu, MIT, CI-checked (shellcheck + checksum drift).