### PR TITLE
Add maint to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ For more details, see [nginx.org](http://nginx.org/en/docs/).
 * [GetPageSpeed Extras for Debian/Ubuntu](https://www.getpagespeed.com/ubuntu-and-debian-repository) - Free APT repository with 100+ pre-built NGINX dynamic modules for Debian (Bookworm/Trixie) and Ubuntu (Bionic/Focal/Jammy/Noble) on amd64 and arm64. No signup or auth required. Covers ModSecurity, brotli, geoip2, headers-more, JWT, TOTP, naxsi, NJS, and a long tail of modules not packaged elsewhere. Cross-distro counterpart for RHEL/SLES/Amazon Linux at extras.getpagespeed.com.
 * [seo-sidecar](https://github.com/Janady13/seo-sidecar) - FastAPI + nginx SSI sidecar that injects fresh Schema.org JSON-LD into nginx-served sites without redeploys or cron jobs. Production-ready, MIT licensed.
 * [nginx-scanner-trap](https://github.com/gistrec/nginx-scanner-trap) - One-script honeypot for existing nginx servers: bots probing paths like /.env or /.git get banned on all ports via fail2ban + nftables. Interactive install with whitelisting, dry-run preview, Debian/Ubuntu, MIT licensed.
+* [maint](https://github.com/glidecraft/nginx-maint) - Toggle nginx maintenance mode per site via a flag file, no reload needed to flip it on or off. Whole-site and partial-site gating snippets included, plus a styled 503 page. MIT licensed.
 
 * [Laradock](https://github.com/laradock/laradock) - Full PHP development environment based on Docker, includes Nginx as one of its swappable services.
 


### PR DESCRIPTION
Adds [maint](https://github.com/glidecraft/nginx-maint), a small CLI + nginx snippets for toggling maintenance mode per site via a flag file (no reload needed to flip it on or off). MIT licensed, one commit added to the Tools section following the existing format.