### PR TITLE
add nwall to c modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ These modules are not distributed with the Nginx source.
 * [nginx-error-abuse-module](https://github.com/myguard-labs/nginx-error-abuse-module) - Watches error responses and bans clients that trigger repeated 4xx/5xx abuse.
 * [nginx-cache-turbo-module](https://github.com/myguard-labs/nginx-cache-turbo-module) - Built-in full-page cache for nginx — a tiny Varnish living inside the worker.
 * [nginx-autocert-module](https://github.com/myguard-labs/nginx-autocert-module) - Automatic TLS certificates built into nginx — ACME/Let's Encrypt issuance and renewal, with wildcard, IP-address certs and TLS-ALPN-01.
+* [nwall](https://github.com/coalaura/nwall) - Ultra-fast bot-spam filter that cuts resource usage by hard-closing requests via User-Agent and URI rules.
 
 ## Rust Modules
 * [ngx-rust](https://github.com/nginxinc/ngx-rust) - Rust bindings for Nginx modules.


### PR DESCRIPTION
Adds nwall, a fast bot-spam filter designed to reduce nginx resource usage by blocking bot spam